### PR TITLE
Write CSV lists using chars not strings

### DIFF
--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -138,7 +138,7 @@ void print_sensors_control() {
       changed = changed != count;
     }
     
-    const char* comma = ",";
+    const char comma = ',';
     Serial.print(gSensorA0_dark_);
     Serial.print(comma);
     Serial.print(gSensorA1_dark_);


### PR DESCRIPTION
The Arduino output stream has an overloaded version
specifically for characters that is much more lightweight
than using a string to represent a single character.